### PR TITLE
Fix: vidéo de présentation invisible sur firefox

### DIFF
--- a/src/components/sections/video.svelte
+++ b/src/components/sections/video.svelte
@@ -36,7 +36,7 @@
   }
 
   .video {
-    flex: 1;
+    flex: 1 1 content;
     width: 100%;
     max-width: 600px;
     height: auto;


### PR DESCRIPTION
## Problème

Sur firefox, la vidéo de présentation est invisible.

C'est dû à la propriété `flex: 1;` sur l'élément vidéo, un shorthand qui s'évalue à:
- `flex-grow: 1;`
- `flex-shrink: 1;`
- `flex-basis: 0%;`

Sur la plupart des navigateurs, cela n'a pas l'air de poser problème, mais sur firefox, la propriété `flex-basis: 0%;` bug et rend la vidéo minuscule (2 pixels de large et de haut) ce qui la réduit à un point clair sur l'écran:

<img width="1103" alt="Capture d’écran 2024-03-27 à 19 14 12" src="https://github.com/PapillonApp/getpapillon-svelte/assets/87938702/bfce9c16-d3b4-4296-afb8-c3f4b20488fa">

## Solution

J'ai donc remplacé `flex: 1;` par `flex: 1 1 content;` qui s'évalue à:
- `flex-grow: 1;`
- `flex-shrink: 1;`
- `flex-basis: content;`

Avec la valeur `content`, la vidéo apparaît sur firefox correctement et de la même taille que sur tous les autres navigateurs.

<img width="1289" alt="Capture d’écran 2024-03-27 à 19 22 39" src="https://github.com/PapillonApp/getpapillon-svelte/assets/87938702/5fe88476-1ec5-4802-af01-26dc78c84535">
